### PR TITLE
Pandoc error bug fix

### DIFF
--- a/app.R
+++ b/app.R
@@ -2552,10 +2552,20 @@ library(zip)
 
 
     })
-
+    ## Create temporary directory in response to creation of server output object
+    ## Needs to happen first thing after the server output is created
+    dir_temp <- observe({
+      req(WGCNA_workflow_results)
+      tempdir()
+    })
     ## Update the inputs for the selection menus when WGCNA_workflow_results finishes
+    ## This observer function: 
+    ## 1. Updates module name depedent picker inputs
+    ## 2. Selects the plots to display in response to user input
+    ## 3. Creates the temporary directory in preparation for call to downloadHandler. 
     observe({
       req(WGCNA_workflow_results())
+      ## Updates the picker input with the names of the modules
       module_names <- fetch_gProfiler_names(WGCNA_workflow_results())
 
       module_colors <- list()
@@ -2583,7 +2593,7 @@ library(zip)
                         inputId = "module_data",
                         choices = module_colors)
 
-      ## WGCNA Diagnostics Plots
+      ## Renders ME plots Diagnostics Plots on input changes
       observe({
         req(WGCNA_workflow_results())
         output$MEPlot <- renderPlot(
@@ -2592,7 +2602,7 @@ library(zip)
                               plot_name = input$module)
         )
       })
-
+      ## Renders gprofiler plots on input change
       observe({
         req(WGCNA_workflow_results())
         output$gProfilerPlot <- renderPlotly(
@@ -2600,7 +2610,7 @@ library(zip)
                                 plot_name = input$selectModule)
         )
       })
-
+      ## Renders Diagnostic plots on input changes
       observe({
         req(WGCNA_workflow_results())
         output$diagnostic_plot <- renderPlot(
@@ -2608,7 +2618,7 @@ library(zip)
                                        plot = input$plot_select)
         )
       })
-
+      ## Renders data tables for displaying propvar, gprofiler, and module membership results
       output$prop_var <- DT::renderDT(
         prop_var_output(WGCNA_workflow_results()),
       )
@@ -2631,12 +2641,8 @@ library(zip)
                                         input$module_data)
         )
       })
-      ## Create temporary directory in response to creation of server output object
-      dir_temp <- observe({
-        req(WGCNA_workflow_results)
-            tempdir()
-            })
-      
+      ## Creates folders and names and save plots for download in a temporary 
+      ## folder in preparation for call to download handler
       observe({
         req(WGCNA_workflow_results())
 
@@ -2657,6 +2663,7 @@ library(zip)
       })
 
     })
+    
     output$downloader <- downloadHandler(
         filename = function(){file.path(paste("WGCNAResults",
                                     "zip",

--- a/app.R
+++ b/app.R
@@ -2656,7 +2656,7 @@ library(zip)
                                     "zip",
                                     sep = "."))},
         content = function(file){
-          file.copy(file.path(dir_temp, "WGCNAResults.zip"), file)
+          file.copy(file.path(dir_temp(), "WGCNAResults.zip"), file)
         },
         contentType = "application/zip"
       )

--- a/app.R
+++ b/app.R
@@ -2238,6 +2238,7 @@ library(zip)
   ### App script
   ### App Settings
   options(shiny.maxRequestSize = 30 * 1024^2)
+  dir_temp <- tempdir()
   ## App library dependencies
 
   if(!require(tidyverse)) install.packages("tidyverse")
@@ -2552,12 +2553,6 @@ library(zip)
 
 
     })
-    ## Create temporary directory in response to creation of server output object
-    ## Needs to happen first thing after the server output is created
-    dir_temp <- observe({
-      req(WGCNA_workflow_results)
-      tempdir()
-    })
     ## Update the inputs for the selection menus when WGCNA_workflow_results finishes
     ## This observer function: 
     ## 1. Updates module name depedent picker inputs
@@ -2653,11 +2648,11 @@ library(zip)
                          "Module_Eigenprotein_Plots/density",
                          "Eigenprotein_Diagnostics")
 
-        dir.create(file.path(dir_temp(), "Results"))
+        dir.create(file.path(dir_temp, "Results"))
         for(i in 1:length(directories)){
-          dir.create(file.path(dir_temp(), "Results", directories[i]))
+          dir.create(file.path(dir_temp, "Results", directories[i]))
         }
-        path_to_temp <- file.path(dir_temp(), "Results")
+        path_to_temp <- file.path(dir_temp, "Results")
         WriteResultsToTempFolder(WGCNA_workflow_results(), path_to_temp)
         zip::zipr(zipfile = file.path(dir_temp, "WGCNAResults.zip"), files = path_to_temp)
       })
@@ -2669,7 +2664,7 @@ library(zip)
                                     "zip",
                                     sep = "."))},
         content = function(file){
-          file.copy(file.path(dir_temp(), "WGCNAResults.zip"), file)
+          file.copy(file.path(dir_temp, "WGCNAResults.zip"), file)
         },
         contentType = "application/zip"
       )

--- a/app.R
+++ b/app.R
@@ -14,6 +14,7 @@ if(!require(shinyWidgets)) install.packages("shinyWidgets", dependencies = TRUE)
 if(!require(gprofiler2)) install.packages("gprofiler2", dependencies = TRUE)
 if(!require(withr)) install.packages("withr")
 if(!require(zip)) devtools::install_github("zip")
+if(!require(rmarkdown)) install.packages("rmarkdown")
 
 library(BiocManager)
 options(repos = BiocManager::repositories())

--- a/app.R
+++ b/app.R
@@ -2631,9 +2631,15 @@ library(zip)
                                         input$module_data)
         )
       })
+      ## Create temporary directory in response to creation of server output object
+      dir_temp <- observe({
+        req(WGCNA_workflow_results)
+            tempdir()
+            })
+      
       observe({
         req(WGCNA_workflow_results())
-        dir_temp <- tempdir()
+
         directories <- c("gProfiler_Plots",
                          "Module_Eigenprotein_Plots",
                          "Module_Eigenprotein_Plots/boxplots",
@@ -2641,11 +2647,11 @@ library(zip)
                          "Module_Eigenprotein_Plots/density",
                          "Eigenprotein_Diagnostics")
 
-        dir.create(file.path(dir_temp, "Results"))
+        dir.create(file.path(dir_temp(), "Results"))
         for(i in 1:length(directories)){
-          dir.create(file.path(dir_temp, "Results", directories[i]))
+          dir.create(file.path(dir_temp(), "Results", directories[i]))
         }
-        path_to_temp <- file.path(dir_temp, "Results")
+        path_to_temp <- file.path(dir_temp(), "Results")
         WriteResultsToTempFolder(WGCNA_workflow_results(), path_to_temp)
         zip::zipr(zipfile = file.path(dir_temp, "WGCNAResults.zip"), files = path_to_temp)
       })


### PR DESCRIPTION
A program called Pandoc is required for using htmlwidget::saveWidget() which is used to save the g:Profiler plots as a self-contained file. When running in MetaNetwork in RStudio or the shiny server, no error occurs. However, if the user is running MetaNetwork via R's endogenous GUI, an error will occur because Pandoc is not automatically installed with R. I'm also adding Pandoc installation guidelines in the README. 